### PR TITLE
Expose a JSON api to query for benchmark results

### DIFF
--- a/app/controllers/concerns/json_generator.rb
+++ b/app/controllers/concerns/json_generator.rb
@@ -1,15 +1,11 @@
 require 'active_support/concern'
 
 module JSONGenerator
-	extend ActiveSupport::Concern
+  extend ActiveSupport::Concern
 
   # Generate the JSON representation of `charts`
   def generate_json(charts, versions, params = {})
-    charts.map do |chart|
-      # rename for clarity
-      result_data = chart[0]
-      result_type = chart[1]
-
+    charts.map do |result_data, result_type|
       datasets = []
       variations = []
       # each column contains an array of datapoints

--- a/app/controllers/concerns/json_generator.rb
+++ b/app/controllers/concerns/json_generator.rb
@@ -1,0 +1,50 @@
+require 'active_support/concern'
+
+module JSONGenerator
+	extend ActiveSupport::Concern
+
+  # Generate the JSON representation of `charts`
+  def generate_json(charts, versions, params = {})
+    charts.map do |chart|
+      # rename for clarity
+      result_data = chart[0]
+      result_type = chart[1]
+
+      datasets = []
+      variations = []
+      # each column contains an array of datapoints
+      JSON.parse(result_data[:columns]).each do |column| 
+        # get one set of datapoints (sometimes there's 2+ sets of data for one chart)
+        datasets << column['data']
+        # This is for when there are two data sets in one chart (ex. rails commits benchmarks)
+        # Example variations: `with_prepared_statements`, `without_prepared_statements`
+        # `column['name']` is the benchmark name when there is only one set of datapoints
+        variations << column['name']
+      end
+
+      # zip the multiple datapoints together
+      first, *rest = *datasets
+      datasets_zip = first.zip(*rest)
+
+      # combine the datapoints with their respective versions
+      # `datasets_zip` and `versions` have the same length
+      datapoints = datasets_zip.zip(versions).reduce([]) do |memo, (points, version)|
+        memo << {
+          values: points,
+          version: version
+        }
+        memo
+      end
+
+      # generate the json
+      config = {
+        benchmark_name: params[:result_type],
+        datapoints: datapoints,
+        measurement: result_type[:name],
+        unit: result_type[:unit]
+      }
+      config[:variations] = variations if variations.length > 1
+      config
+    end
+  end
+end

--- a/app/controllers/repos_controller.rb
+++ b/app/controllers/repos_controller.rb
@@ -97,11 +97,8 @@ class ReposController < ApplicationController
     if (@form_result_type = params[:result_type]) &&
        (@benchmark_type = find_benchmark_type_by_category(@form_result_type))
 
-      save_versions = true
+      versions_calculate_once = ActiveSupport::OrderedHash.new
       @charts = @benchmark_type.benchmark_result_types.map do |benchmark_result_type|
-        # save the versions
-        @versions = [] if save_versions
-
         benchmark_runs = BenchmarkRun.fetch_release_benchmark_runs(
           @form_result_type, benchmark_result_type
         )
@@ -126,13 +123,13 @@ class ReposController < ApplicationController
             config[:environment] = environment
           end
 
-          @versions << config if save_versions
+          versions_calculate_once[config[:version]] = config unless @versions
 
           # generate HTML
           "Version: #{config[:version]}<br>" \
           "#{environment}"
         end
-        save_versions = false
+        @versions ||= versions_calculate_once.values
 
         [columns, benchmark_result_type]
       end.compact

--- a/app/controllers/repos_controller.rb
+++ b/app/controllers/repos_controller.rb
@@ -87,7 +87,7 @@ class ReposController < ApplicationController
         @result_types = fetch_categories
       end
 
-      format.json { render :json => generate_json(:commits) }
+      format.json { render json: generate_json(:commits) }
 
       format.js
     end
@@ -141,7 +141,7 @@ class ReposController < ApplicationController
         @result_types = fetch_categories
       end
 
-      format.json { render :json => generate_json(:releases) }
+      format.json { render json: generate_json(:releases) }
 
       format.js
     end

--- a/app/controllers/repos_controller.rb
+++ b/app/controllers/repos_controller.rb
@@ -35,7 +35,7 @@ class ReposController < ApplicationController
       @charts = @benchmark_type.benchmark_result_types.map do |benchmark_result_type|
         cache_key = "#{BenchmarkRun.charts_cache_key(@benchmark_type, benchmark_result_type)}:#{@benchmark_run_display_count}"
 
-        if (columns = $redis.get(cache_key)) && (versions)
+        if versions && columns = $redis.get(cache_key)
           [JSON.parse(columns).symbolize_keys!, benchmark_result_type]
         else
           benchmark_runs = BenchmarkRun.fetch_commit_benchmark_runs(
@@ -60,6 +60,7 @@ class ReposController < ApplicationController
               commit_message: commit.message.truncate(30)
             }
             if environment.is_a?(Hash)
+              # use the key(s) in `environment` instead of setting `config[:environment`]
               config.merge!(environment)
               # solely for the purpose of generating the correct HTML
               environment = hash_to_html(environment)
@@ -117,6 +118,7 @@ class ReposController < ApplicationController
           # generate the version object
           config = { version: benchmark_run.initiator.version }
           if environment.is_a?(Hash)
+            # use the key(s) in `environment` instead of setting `config[:environment`]
             config.merge!(environment)
             # solely for the purpose of generating the correct HTML
             environment = hash_to_html(environment)

--- a/app/controllers/repos_controller.rb
+++ b/app/controllers/repos_controller.rb
@@ -168,23 +168,36 @@ class ReposController < ApplicationController
       result_data = chart[0]
       result_type = chart[1]
 
-      datapoints = []
+      datasets = []
       variations = []
       # each column contains an array of datapoints
       JSON.parse(result_data[:columns]).each do |column| 
         # get one set of datapoints (sometimes there's 2+ sets of data for one chart)
-        datapoints << column['data']
+        datasets << column['data']
         # This is for when there are two data sets in one chart (ex. rails commits benchmarks)
         # Example variations: `with_prepared_statements`, `without_prepared_statements`
         # `column['name']` is the benchmark name when there is only one set of datapoints
         variations << column['name']
       end
 
+      # zip the multiple datapoints together
+      first, *rest = *datasets
+      datasets_zip = first.zip(*rest)
+
+      # combine the datapoints with their respective versions
+      # `datasets_zip` and `versions` have the same length
+      datapoints = datasets_zip.zip(versions).reduce([]) do |memo, (points, version)|
+        memo << {
+          values: points,
+          "#{@repo.name}_version".to_sym => version
+        }
+        memo
+      end
+
       # generate the json
       config = {
         benchmark_name: params[:result_type],
         datapoints: datapoints,
-        "#{@repo.name}_versions".to_sym => versions,
         measurement: result_type[:name],
         unit: result_type[:unit]
       }

--- a/app/controllers/repos_controller.rb
+++ b/app/controllers/repos_controller.rb
@@ -2,6 +2,8 @@ class ReposController < ApplicationController
   before_action :find_organization_by_name
   before_action :find_organization_repo_by_name
 
+  include JSONGenerator
+
   def index
     @charts =
       if charts = $redis.get("sparklines:#{@repo.id}")
@@ -87,7 +89,7 @@ class ReposController < ApplicationController
       format.html do
         @result_types = fetch_categories
       end
-      format.json { render json: generate_json(@charts, @versions) }
+      format.json { render json: generate_json(@charts, @versions, params) }
       format.js
     end
   end
@@ -138,7 +140,7 @@ class ReposController < ApplicationController
       format.html do
         @result_types = fetch_categories
       end
-      format.json { render json: generate_json(@charts, @versions) }
+      format.json { render json: generate_json(@charts, @versions, params) }
       format.js
     end
   end
@@ -159,51 +161,6 @@ class ReposController < ApplicationController
 
   def fetch_categories
     @repo.benchmark_types.pluck(:category)
-  end
-
-  # Generate the JSON representation of `charts`
-  def generate_json(charts, versions)
-    charts.map do |chart|
-      # rename for clarity
-      result_data = chart[0]
-      result_type = chart[1]
-
-      datasets = []
-      variations = []
-      # each column contains an array of datapoints
-      JSON.parse(result_data[:columns]).each do |column| 
-        # get one set of datapoints (sometimes there's 2+ sets of data for one chart)
-        datasets << column['data']
-        # This is for when there are two data sets in one chart (ex. rails commits benchmarks)
-        # Example variations: `with_prepared_statements`, `without_prepared_statements`
-        # `column['name']` is the benchmark name when there is only one set of datapoints
-        variations << column['name']
-      end
-
-      # zip the multiple datapoints together
-      first, *rest = *datasets
-      datasets_zip = first.zip(*rest)
-
-      # combine the datapoints with their respective versions
-      # `datasets_zip` and `versions` have the same length
-      datapoints = datasets_zip.zip(versions).reduce([]) do |memo, (points, version)|
-        memo << {
-          values: points,
-          "#{@repo.name}_version".to_sym => version
-        }
-        memo
-      end
-
-      # generate the json
-      config = {
-        benchmark_name: params[:result_type],
-        datapoints: datapoints,
-        measurement: result_type[:name],
-        unit: result_type[:unit]
-      }
-      config[:variations] = variations if variations.length > 1
-      config
-    end
   end
 
   # Generate an HTML string representing the `hash`, with each pair on a new line

--- a/test/controllers/concerns/json_generator_test.rb
+++ b/test/controllers/concerns/json_generator_test.rb
@@ -1,0 +1,29 @@
+require 'test_helper'
+
+class JSONGeneratorTest < ActiveSupport::TestCase
+	include JSONGenerator
+
+	testcases = JSON.parse(file_fixture("json_generator_tests.json").read, symbolize_names: true)
+
+	test "JSON generation works when there is one dataset in chart" do
+		testcase = testcases[:test_one_dataset_in_chart]
+		charts = testcase[:charts]
+		versions = testcase[:versions]
+
+		assert_equal(
+			generate_json(charts, versions, { result_type: "ao_bench" }).to_json,
+			testcase[:expected].to_json
+		)
+	end
+
+	test "JSON generation works when there are two datasets in chart" do
+		testcase = testcases[:test_two_datasets_in_chart]
+		charts = testcase[:charts]
+		versions = testcase[:versions]
+
+		assert_equal(
+			generate_json(charts, versions, { result_type: "ao_bench" }).to_json,
+			testcase[:expected].to_json
+		)
+	end
+end

--- a/test/controllers/concerns/json_generator_test.rb
+++ b/test/controllers/concerns/json_generator_test.rb
@@ -1,29 +1,29 @@
 require 'test_helper'
 
 class JSONGeneratorTest < ActiveSupport::TestCase
-	include JSONGenerator
+  include JSONGenerator
 
-	testcases = JSON.parse(file_fixture("json_generator_tests.json").read, symbolize_names: true)
+  testcases = JSON.parse(file_fixture("json_generator_tests.json").read, symbolize_names: true)
 
-	test "JSON generation works when there is one dataset in chart" do
-		testcase = testcases[:test_one_dataset_in_chart]
-		charts = testcase[:charts]
-		versions = testcase[:versions]
+  test "JSON generation works when there is one dataset in chart" do
+    testcase = testcases[:test_one_dataset_in_chart]
+    charts = testcase[:charts]
+    versions = testcase[:versions]
 
-		assert_equal(
-			generate_json(charts, versions, { result_type: "ao_bench" }).to_json,
-			testcase[:expected].to_json
-		)
-	end
+    assert_equal(
+      generate_json(charts, versions, { result_type: "ao_bench" }).to_json,
+      testcase[:expected].to_json
+    )
+  end
 
-	test "JSON generation works when there are two datasets in chart" do
-		testcase = testcases[:test_two_datasets_in_chart]
-		charts = testcase[:charts]
-		versions = testcase[:versions]
+  test "JSON generation works when there are two datasets in chart" do
+    testcase = testcases[:test_two_datasets_in_chart]
+    charts = testcase[:charts]
+    versions = testcase[:versions]
 
-		assert_equal(
-			generate_json(charts, versions, { result_type: "ao_bench" }).to_json,
-			testcase[:expected].to_json
-		)
-	end
+    assert_equal(
+      generate_json(charts, versions, { result_type: "ao_bench" }).to_json,
+      testcase[:expected].to_json
+    )
+  end
 end

--- a/test/fixtures/files/json_generator_tests.json
+++ b/test/fixtures/files/json_generator_tests.json
@@ -1,95 +1,95 @@
 {
-	"test_one_dataset_in_chart": {
-		"charts": [
-			[  
-		    {  
-		      "columns":"[{\"name\":\"ao_bench\",\"data\":[0.22,0.22]}]"
-		    },
-		    {  
-		      "name":"Execution time",
-		      "unit":"Seconds"
-		    }
-		  ]
-		],
-		"versions": [  
-		  {  
-		    "version":"0",
-		    "environment":"ruby 2.2.0dev"
-		  },
-		  {  
-		    "version":"1",
-		    "environment":"ruby 2.2.0dev"
-		  }
-		],
-		"expected": [
-		  {  
-		    "benchmark_name":"ao_bench",
-		    "datapoints":[  
-		      {  
-		        "values":[0.22],
-		        "version":{  
-		          "version":"0",
-		          "environment":"ruby 2.2.0dev"
-		        }
-		      },
-		      {  
-		        "values":[0.22],
-		        "version":{  
-		          "version":"1",
-		          "environment":"ruby 2.2.0dev"
-		        }
-		      }
-		    ],
-		    "measurement":"Execution time",
-		    "unit":"Seconds"
-		  }
-		]
-	},
-	"test_two_datasets_in_chart": {
-		"charts": [  
-		  [  
-		    {  
-		      "columns":"[{\"name\":\"abc\",\"data\":[0.22,0.22]},{\"name\":\"def\",\"data\":[0.44,0.44]}]"
-		    },
-		    {  
-		      "name":"Execution time",
-		      "unit":"Seconds"
-		    }
-		  ]
-		],
-		"versions": [  
-		  {  
-		    "version":"0",
-		    "environment":"ruby 2.2.0dev"
-		  },
-		  {  
-		    "version":"1",
-		    "environment":"ruby 2.2.0dev"
-		  }
-		],
-		"expected": [
-		  {  
-		    "benchmark_name":"ao_bench",
-		    "datapoints":[  
-		      {  
-		        "values":[0.22, 0.44],
-		        "version":{  
-		          "version":"0",
-		          "environment":"ruby 2.2.0dev"
-		        }
-		      },
-		      {  
-		        "values":[0.22, 0.44],
-		        "version":{  
-		          "version":"1",
-		          "environment":"ruby 2.2.0dev"
-		        }
-		      }
-		    ],
-		    "measurement":"Execution time",
-		    "unit":"Seconds",
-		    "variations":["abc","def"]
-		  }
-		]
-	}
+  "test_one_dataset_in_chart": {
+    "charts": [
+      [  
+        {  
+          "columns":"[{\"name\":\"ao_bench\",\"data\":[0.22,0.22]}]"
+        },
+        {  
+          "name":"Execution time",
+          "unit":"Seconds"
+        }
+      ]
+    ],
+    "versions": [  
+      {  
+        "version":"0",
+        "environment":"ruby 2.2.0dev"
+      },
+      {  
+        "version":"1",
+        "environment":"ruby 2.2.0dev"
+      }
+    ],
+    "expected": [
+      {  
+        "benchmark_name":"ao_bench",
+        "datapoints":[  
+          {  
+            "values":[0.22],
+            "version":{  
+              "version":"0",
+              "environment":"ruby 2.2.0dev"
+            }
+          },
+          {  
+            "values":[0.22],
+            "version":{  
+              "version":"1",
+              "environment":"ruby 2.2.0dev"
+            }
+          }
+        ],
+        "measurement":"Execution time",
+        "unit":"Seconds"
+      }
+    ]
+  },
+  "test_two_datasets_in_chart": {
+    "charts": [  
+      [  
+        {  
+          "columns":"[{\"name\":\"abc\",\"data\":[0.22,0.22]},{\"name\":\"def\",\"data\":[0.44,0.44]}]"
+        },
+        {  
+          "name":"Execution time",
+          "unit":"Seconds"
+        }
+      ]
+    ],
+    "versions": [  
+      {  
+        "version":"0",
+        "environment":"ruby 2.2.0dev"
+      },
+      {  
+        "version":"1",
+        "environment":"ruby 2.2.0dev"
+      }
+    ],
+    "expected": [
+      {  
+        "benchmark_name":"ao_bench",
+        "datapoints":[  
+          {  
+            "values":[0.22, 0.44],
+            "version":{  
+              "version":"0",
+              "environment":"ruby 2.2.0dev"
+            }
+          },
+          {  
+            "values":[0.22, 0.44],
+            "version":{  
+              "version":"1",
+              "environment":"ruby 2.2.0dev"
+            }
+          }
+        ],
+        "measurement":"Execution time",
+        "unit":"Seconds",
+        "variations":["abc","def"]
+      }
+    ]
+  }
 }

--- a/test/fixtures/files/json_generator_tests.json
+++ b/test/fixtures/files/json_generator_tests.json
@@ -1,0 +1,95 @@
+{
+	"test_one_dataset_in_chart": {
+		"charts": [
+			[  
+		    {  
+		      "columns":"[{\"name\":\"ao_bench\",\"data\":[0.22,0.22]}]"
+		    },
+		    {  
+		      "name":"Execution time",
+		      "unit":"Seconds"
+		    }
+		  ]
+		],
+		"versions": [  
+		  {  
+		    "version":"0",
+		    "environment":"ruby 2.2.0dev"
+		  },
+		  {  
+		    "version":"1",
+		    "environment":"ruby 2.2.0dev"
+		  }
+		],
+		"expected": [
+		  {  
+		    "benchmark_name":"ao_bench",
+		    "datapoints":[  
+		      {  
+		        "values":[0.22],
+		        "version":{  
+		          "version":"0",
+		          "environment":"ruby 2.2.0dev"
+		        }
+		      },
+		      {  
+		        "values":[0.22],
+		        "version":{  
+		          "version":"1",
+		          "environment":"ruby 2.2.0dev"
+		        }
+		      }
+		    ],
+		    "measurement":"Execution time",
+		    "unit":"Seconds"
+		  }
+		]
+	},
+	"test_two_datasets_in_chart": {
+		"charts": [  
+		  [  
+		    {  
+		      "columns":"[{\"name\":\"abc\",\"data\":[0.22,0.22]},{\"name\":\"def\",\"data\":[0.44,0.44]}]"
+		    },
+		    {  
+		      "name":"Execution time",
+		      "unit":"Seconds"
+		    }
+		  ]
+		],
+		"versions": [  
+		  {  
+		    "version":"0",
+		    "environment":"ruby 2.2.0dev"
+		  },
+		  {  
+		    "version":"1",
+		    "environment":"ruby 2.2.0dev"
+		  }
+		],
+		"expected": [
+		  {  
+		    "benchmark_name":"ao_bench",
+		    "datapoints":[  
+		      {  
+		        "values":[0.22, 0.44],
+		        "version":{  
+		          "version":"0",
+		          "environment":"ruby 2.2.0dev"
+		        }
+		      },
+		      {  
+		        "values":[0.22, 0.44],
+		        "version":{  
+		          "version":"1",
+		          "environment":"ruby 2.2.0dev"
+		        }
+		      }
+		    ],
+		    "measurement":"Execution time",
+		    "unit":"Seconds",
+		    "variations":["abc","def"]
+		  }
+		]
+	}
+}

--- a/test/integration/repos_test.rb
+++ b/test/integration/repos_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class ReposTest < ActionDispatch::IntegrationTest
 
-	testcases = JSON.parse(file_fixture("json_generator_tests.json").read, symbolize_names: true)
+  testcases = JSON.parse(file_fixture("json_generator_tests.json").read, symbolize_names: true)
 
   test "organization should a required parameter for show action" do
     organization = create(:organization, name: 'rails')
@@ -39,10 +39,10 @@ class ReposTest < ActionDispatch::IntegrationTest
     )
 
     get "/#{org.name}/#{repo.name}/commits.json?result_type=#{benchmark_type.category}", 
-	    params: { display_count: 2, result_type: benchmark_result_type }
+      params: { display_count: 2, result_type: benchmark_result_type }
 
-	  chart = JSON.parse(response.body, symbolize_names: true)[0]
-	  # must have these 4 keys
+    chart = JSON.parse(response.body, symbolize_names: true)[0]
+    # must have these 4 keys
     assert ([:benchmark_name, :datapoints, :measurement, :unit] - chart.keys).empty?
   end
 end

--- a/test/integration/repos_test.rb
+++ b/test/integration/repos_test.rb
@@ -1,6 +1,9 @@
 require 'test_helper'
 
 class ReposTest < ActionDispatch::IntegrationTest
+
+	testcases = JSON.parse(file_fixture("json_generator_tests.json").read, symbolize_names: true)
+
   test "organization should a required parameter for show action" do
     organization = create(:organization, name: 'rails')
     create(:repo, name: 'rails', organization: organization)
@@ -11,5 +14,35 @@ class ReposTest < ActionDispatch::IntegrationTest
     assert_raise(ActionController::RoutingError) do
       get '/tgxworld/rails'
     end
+  end
+
+  test "query JSON endpoint should return JSON object" do
+    benchmark_type = create(:benchmark_type)
+    benchmark_result_type = create(:benchmark_result_type)
+
+    repo = benchmark_type.repo
+    org = repo.organization
+
+    commit = create(:commit, repo: repo)
+    later_commit = create(:commit, repo: repo, created_at: Time.zone.now + 1.day)
+
+    benchmark_run = create(:commit_benchmark_run,
+      benchmark_result_type: benchmark_result_type,
+      benchmark_type: benchmark_type,
+      initiator: commit
+    )
+
+    benchmark_run2 = create(:commit_benchmark_run,
+      benchmark_result_type: benchmark_result_type,
+      benchmark_type: benchmark_type,
+      initiator: later_commit
+    )
+
+    get "/#{org.name}/#{repo.name}/commits.json?result_type=#{benchmark_type.category}", 
+	    params: { display_count: 2, result_type: benchmark_result_type }
+
+	  chart = JSON.parse(response.body, symbolize_names: true)[0]
+	  # must have these 4 keys
+    assert ([:benchmark_name, :datapoints, :measurement, :unit] - chart.keys).empty?
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,4 +9,8 @@ Dir["#{Rails.root}/test/support/**/*"].each { |file| require file }
 class ActiveSupport::TestCase
   # Add more helper methods to be used by all tests here...
   include FactoryGirl::Syntax::Methods
+
+  def self.file_fixture(name)
+  	Rails.root.join('test', 'fixtures', 'files', name)
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,6 +11,6 @@ class ActiveSupport::TestCase
   include FactoryGirl::Syntax::Methods
 
   def self.file_fixture(name)
-  	Rails.root.join('test', 'fixtures', 'files', name)
+    Rails.root.join('test', 'fixtures', 'files', name)
   end
 end


### PR DESCRIPTION
Normally, the web app uses a url like 
`https://rubybench.org/ruby/ruby/releases?result_type=app_fib` 
to display benchmark results

This PR allows us to get JSON versions of the results by sending requests to
`https://rubybench.org/ruby/ruby/releases.json?result_type=app_fib`

An example of what the JSON results looks like:
https://gist.github.com/jerryliu55/e89e007386018977b6b8fa87c9e71f0f

@burke @jules2689 @kirs